### PR TITLE
Progress vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a57ed03a3563e9d6214c1eec5bd3b151fc21fb2052448b97692c8df30d113c8c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,6 +1173,7 @@ name = "progresslib2"
 version = "2.0.0"
 dependencies = [
  "actix-web",
+ "delegate",
  "futures",
  "futures-timer",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 tokio = { version = "0.2.23", features = ["full"] }
 futures = "0.3.7"
 futures-timer = "3.0.2"
+delegate = "0.5.0"
 
 [dev-dependencies]
 actix-web = "3"

--- a/examples/youtubedl.rs
+++ b/examples/youtubedl.rs
@@ -116,7 +116,7 @@ pub async fn download_video(
     };
 
     match status.success() {
-        true => Ok(()),
+        true => Ok(None),
         false => {
             let error_code = status.code();
             if let None = error_code {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ use std::{any::Any, time::Duration};
 use delegate::delegate;
 use std::collections::hash_map::Drain;
 
+mod progress_compute;
+pub use progress_compute::*;
 
 mod progress_vars;
 pub use progress_vars::*;
@@ -129,9 +131,6 @@ impl Stage {
     }
 }
 
-pub const MAX_PROGRESS_TICKS: u32 = 100_000;
-pub const TICKS_PER_PERCENT: u32 = MAX_PROGRESS_TICKS / 100;
-
 #[derive(Debug, Clone)]
 pub struct ProgressError {
     pub name: Option<String>,
@@ -227,7 +226,7 @@ pub struct ProgressItem {
     started: bool,
     numstages: usize,
     current_stage: Option<(usize, Stage)>,
-    progress: u32, // 0 - 100,000 (each 1,000 is 1%)
+    progress: ProgressCompute,
     errored: Option<ProgressError>,
     done: bool,
     max_lock_attempts: usize,
@@ -248,7 +247,7 @@ impl Default for ProgressItem {
             current_stage: None,
             errored: None,
             done: false,
-            progress: 0,
+            progress: ProgressCompute::default(),
             max_lock_attempts: 3,
             lock_attempt_wait: 1000,
             paused: false,
@@ -261,6 +260,7 @@ impl Default for ProgressItem {
 
 impl ProgressItem {
     delegate_progressvars_on!(vars);
+    delegate_progresscompute_on!(progress);
 
     // TODO: decide what to do with name... should it be part of progress item or not?
     pub fn new() -> Self {
@@ -284,71 +284,6 @@ impl ProgressItem {
     pub fn get_progress_error(&self) -> &Option<ProgressError> {
         &self.errored
     }
-
-    /// set the progress level. new_progress must be in 'ticks'
-    /// where 1000 ticks represents 1%
-    pub fn set_progress(&mut self, new_progress: u32) {
-        if new_progress > MAX_PROGRESS_TICKS as u32 {
-            self.progress = MAX_PROGRESS_TICKS;
-        } else {
-            // this is safe to do because we checked if its over 100,000 which if its not
-            // then it will definitely fit into u32
-            self.progress = new_progress;
-        }
-    }
-
-    /// prog_percent is a float64 from 0.0-100.0 inclusively
-    pub fn set_progress_percent(&mut self, prog_percent: f64) {
-        if prog_percent < 0 as f64 {
-            return;
-        }
-
-        let new_ticks = prog_percent * TICKS_PER_PERCENT as f64;
-        self.set_progress(new_ticks as u32);
-    }
-
-    /// prog_norm is a float64 from 0.0-1.0 inclusively where 0.0
-    /// represents 0%, and 1.0 represents 100%
-    pub fn set_progress_percent_normalized(&mut self, prog_norm: f64) {
-        self.set_progress_percent(prog_norm * 100.0);
-    }
-
-    /// like set_progress but only allows progress to increase
-    pub fn inc_progress(&mut self, new_progress: u32) {
-        if new_progress > self.progress {
-            self.set_progress(new_progress);
-        }
-    }
-
-    /// like set_progress_percent but only allows increasing the progress
-    pub fn inc_progress_percent(&mut self, new_progress: f64) {
-        if new_progress < 0 as f64 {
-            return;
-        }
-
-        let new_ticks = new_progress * TICKS_PER_PERCENT as f64;
-        self.inc_progress(new_ticks as u32);
-    }
-
-    /// like set_progress_percent_normalized but only allows increasing
-    pub fn inc_progress_percent_normalized(&mut self, prog_norm: f64) {
-        self.inc_progress_percent(prog_norm * 100.0);
-    }
-
-    /// returns a value between 0 and 1 (inclusive) of the percentage
-    /// normalized. ie: 1 <-> 100%, 0 <-> 0%
-    pub fn get_progress_percent_normalized(&self) -> f64 {
-        let percent_norm = self.progress as f64 / MAX_PROGRESS_TICKS as f64;
-        percent_norm
-    }
-
-    /// returns a value between 0.0 and 100.0 of the percentage
-    pub fn get_progress_percent(&self) -> f64 {
-        let percent_norm = self.get_progress_percent_normalized();
-        percent_norm * 100.0
-    }
-
-    pub fn get_progress(&self) -> u32 { self.progress }
 
     pub fn has_started(&self) -> bool { self.started }
 
@@ -470,7 +405,7 @@ impl ProgressItem {
                     name: stage.name,
                     task: None,
                 }));
-                self.progress = 0;
+                self.set_progress(0);
 
                 tokio::spawn(async move {
                     let task_result = task.await;
@@ -1012,38 +947,6 @@ mod tests {
 
         myprog.set_progress_percent_normalized(0.9999);
         assert_eq!(myprog.get_progress_percent_normalized(), 0.9999);
-    }
-
-    #[test]
-    fn set_progress_percent_works() {
-        let mut myprog = ProgressItem::new();
-        myprog.set_progress_percent(0.0);
-        assert_eq!(myprog.get_progress(), 0);
-        myprog.set_progress_percent(22.5);
-        let expected_ticks = 22.5 * TICKS_PER_PERCENT as f64;
-        let expected_ticks = expected_ticks as u32;
-        assert_eq!(myprog.get_progress(), expected_ticks);
-        myprog.set_progress_percent(99.9999999);
-        assert_ne!(myprog.get_progress(), MAX_PROGRESS_TICKS);
-    }
-
-    #[test]
-    fn inc_progress_works_percent() {
-        let mut myprog = ProgressItem::new();
-        myprog.set_progress(TICKS_PER_PERCENT * 3);
-        assert_eq!(myprog.get_progress(), TICKS_PER_PERCENT * 3);
-        myprog.inc_progress(TICKS_PER_PERCENT * 10);
-        assert_eq!(myprog.get_progress(), TICKS_PER_PERCENT * 10);
-        myprog.inc_progress(TICKS_PER_PERCENT * 3);
-        // it should still be 10%, cant go down with inc_progress
-        assert_eq!(myprog.get_progress(), TICKS_PER_PERCENT * 10);
-    }
-
-    #[test]
-    fn set_progress_works() {
-        let mut myprog = ProgressItem::new();
-        myprog.set_progress(TICKS_PER_PERCENT);
-        assert_eq!(myprog.get_progress(), TICKS_PER_PERCENT);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,6 +611,29 @@ pub fn use_me_from_progress_holder_or_error<'a, K: Eq + Hash + Debug>(
     }
 }
 
+/// useful when you want to extract something
+/// from the progress item
+pub fn return_something_from_progress_holder<'a, T, K: Eq + Hash + Debug>(
+    key: &K,
+    progholder: &'a Mutex<ProgressHolder<K>>,
+    ok_cb: impl FnMut(&mut ProgressItem) -> Option<T> + 'a,
+) -> Option<T> {
+    let mut mut_ok_cb = ok_cb;
+    match progholder.try_lock() {
+        Err(_) => {
+            None
+        },
+        Ok(mut guard) => match guard.progresses.get_mut(key) {
+            None => {
+                None
+            },
+            Some(me) => {
+                mut_ok_cb(me)
+            }
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use std::{any::Any, time::Duration};
 
 
 pub type ProgressVars = HashMap<String, Box<dyn Any>>;
-pub type TaskResult = Result<(), String>;
+pub type TaskResult = Result<Option<ProgressVars>, String>;
 type PinBoxFuture = Pin<Box<dyn Future<Output = TaskResult> + Send>>;
 type PinBoxFutureSimple = Pin<Box<dyn Future<Output = ()> + Send>>;
 
@@ -83,7 +83,7 @@ impl Stage {
     ) -> Self {
         self.task = Some(Box::pin(async move {
             future.await;
-            Ok(())
+            Ok(None)
         }));
         self
     }
@@ -119,7 +119,7 @@ impl Stage {
     ) -> Self {
         Stage::new(name).set_task_from_future(async move {
             future.await;
-            Ok(())
+            Ok(None)
         })
     }
 }
@@ -647,7 +647,7 @@ mod tests {
 
     async fn download_something(secs: u64) -> TaskResult {
         delay_millis(secs * 1000).await;
-        Ok(())
+        Ok(None)
     }
 
     async fn delay_millis(millis: u64) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,10 @@ use std::sync::Mutex;
 use std::collections::VecDeque;
 use std::collections::HashMap;
 use std::pin::Pin;
-use std::time::Duration;
+use std::{any::Any, time::Duration};
 
 
+pub type ProgressVars = HashMap<String, Box<dyn Any>>;
 pub type TaskResult = Result<(), String>;
 type PinBoxFuture = Pin<Box<dyn Future<Output = TaskResult> + Send>>;
 type PinBoxFutureSimple = Pin<Box<dyn Future<Output = ()> + Send>>;
@@ -739,6 +740,22 @@ mod tests {
             Some(ref progitem) => {
                 Some(progitem.get_progress())
             }
+        }
+    }
+
+    #[test]
+    fn can_use_progress_vars() {
+        let mut progvars = ProgressVars::new();
+        let key = "key";
+        progvars.insert(
+            String::from(key),
+            Box::new(String::from("some value"))
+        );
+        let boxed = progvars.remove(key).unwrap();
+        if let Ok(x) = boxed.downcast::<String>() {
+            assert_eq!(x.as_str(), "some value");
+        } else {
+            assert!(false);
         }
     }
 

--- a/src/progress_compute.rs
+++ b/src/progress_compute.rs
@@ -1,0 +1,134 @@
+pub const MAX_PROGRESS_TICKS: u32 = 100_000;
+pub const TICKS_PER_PERCENT: u32 = MAX_PROGRESS_TICKS / 100;
+
+/// used to represent a progress percentage
+/// internally keeps a progress value as ticks, where
+/// ticks range from 0 to 100,000. every 1000 ticks
+/// is 1%.
+#[derive(Default)]
+pub struct ProgressCompute {
+    ticks: u32,
+}
+
+#[macro_export]
+macro_rules! delegate_progresscompute_on {
+    ($name:tt) => {
+        delegate ! {
+            to self.$name {
+                pub fn set_progress(&mut self, new_progress: u32);
+                pub fn set_progress_percent(&mut self, prog_percent: f64);
+                pub fn set_progress_percent_normalized(&mut self, prog_norm: f64);
+                pub fn inc_progress(&mut self, new_progress: u32);
+                pub fn inc_progress_percent(&mut self, new_progress: f64);
+                pub fn inc_progress_percent_normalized(&mut self, prog_norm: f64);
+                pub fn get_progress_percent_normalized(&self) -> f64;
+                pub fn get_progress_percent(&self) -> f64;
+                pub fn get_progress(&self) -> u32;
+            }
+        }
+    };
+}
+
+impl ProgressCompute {
+    /// set the progress level. new_progress must be in 'ticks'
+    /// where 1000 ticks represents 1%
+    pub fn set_progress(&mut self, new_progress: u32) {
+        if new_progress > MAX_PROGRESS_TICKS as u32 {
+            self.ticks = MAX_PROGRESS_TICKS;
+        } else {
+            // this is safe to do because we checked if its over 100,000 which if its not
+            // then it will definitely fit into u32
+            self.ticks = new_progress;
+        }
+    }
+
+    /// prog_percent is a float64 from 0.0-100.0 inclusively
+    pub fn set_progress_percent(&mut self, prog_percent: f64) {
+        if prog_percent < 0 as f64 {
+            return;
+        }
+
+        let new_ticks = prog_percent * TICKS_PER_PERCENT as f64;
+        self.set_progress(new_ticks as u32);
+    }
+
+    /// prog_norm is a float64 from 0.0-1.0 inclusively where 0.0
+    /// represents 0%, and 1.0 represents 100%
+    pub fn set_progress_percent_normalized(&mut self, prog_norm: f64) {
+        self.set_progress_percent(prog_norm * 100.0);
+    }
+
+    /// like set_progress but only allows progress to increase
+    pub fn inc_progress(&mut self, new_progress: u32) {
+        if new_progress > self.ticks {
+            self.set_progress(new_progress);
+        }
+    }
+
+    /// like set_progress_percent but only allows increasing the progress
+    pub fn inc_progress_percent(&mut self, new_progress: f64) {
+        if new_progress < 0 as f64 {
+            return;
+        }
+
+        let new_ticks = new_progress * TICKS_PER_PERCENT as f64;
+        self.inc_progress(new_ticks as u32);
+    }
+
+    /// like set_progress_percent_normalized but only allows increasing
+    pub fn inc_progress_percent_normalized(&mut self, prog_norm: f64) {
+        self.inc_progress_percent(prog_norm * 100.0);
+    }
+
+    /// returns a value between 0 and 1 (inclusive) of the percentage
+    /// normalized. ie: 1 <-> 100%, 0 <-> 0%
+    pub fn get_progress_percent_normalized(&self) -> f64 {
+        let percent_norm = self.ticks as f64 / MAX_PROGRESS_TICKS as f64;
+        percent_norm
+    }
+
+    /// returns a value between 0.0 and 100.0 of the percentage
+    pub fn get_progress_percent(&self) -> f64 {
+        let percent_norm = self.get_progress_percent_normalized();
+        percent_norm * 100.0
+    }
+
+    pub fn get_progress(&self) -> u32 { self.ticks }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_progress_percent_works() {
+        let mut myprog = ProgressCompute::default();
+        myprog.set_progress_percent(0.0);
+        assert_eq!(myprog.get_progress(), 0);
+        myprog.set_progress_percent(22.5);
+        let expected_ticks = 22.5 * TICKS_PER_PERCENT as f64;
+        let expected_ticks = expected_ticks as u32;
+        assert_eq!(myprog.get_progress(), expected_ticks);
+        myprog.set_progress_percent(99.9999999);
+        assert_ne!(myprog.get_progress(), MAX_PROGRESS_TICKS);
+    }
+
+    #[test]
+    fn inc_progress_works_percent() {
+        let mut myprog = ProgressCompute::default();
+        myprog.set_progress(TICKS_PER_PERCENT * 3);
+        assert_eq!(myprog.get_progress(), TICKS_PER_PERCENT * 3);
+        myprog.inc_progress(TICKS_PER_PERCENT * 10);
+        assert_eq!(myprog.get_progress(), TICKS_PER_PERCENT * 10);
+        myprog.inc_progress(TICKS_PER_PERCENT * 3);
+        // it should still be 10%, cant go down with inc_progress
+        assert_eq!(myprog.get_progress(), TICKS_PER_PERCENT * 10);
+    }
+
+    #[test]
+    fn set_progress_works() {
+        let mut myprog = ProgressCompute::default();
+        myprog.set_progress(TICKS_PER_PERCENT);
+        assert_eq!(myprog.get_progress(), TICKS_PER_PERCENT);
+    }
+}

--- a/src/progress_vars.rs
+++ b/src/progress_vars.rs
@@ -1,0 +1,73 @@
+use std::collections::HashMap;
+use std::any::Any;
+use std::collections::hash_map::Drain;
+
+pub type ProgressVar = Box<dyn Any + Send>;
+#[derive(Debug, Default)]
+pub struct ProgressVars {
+    vars: HashMap<String, ProgressVar>,
+}
+
+#[macro_export]
+macro_rules! delegate_progressvars_on {
+    ($name:tt) => {
+        delegate ! {
+            to self.$name {
+                pub fn extract_var<S: AsRef<str>>(&mut self, key: S) -> Option<Box<dyn Any + Send>>;
+                pub fn insert_var<S: AsRef<str>>(&mut self, key: S, boxed: Box<dyn Any + Send>);
+                pub fn var_exists<S: AsRef<str>>(&self, key: S) -> bool;
+                pub fn drain_vars(&mut self) -> Drain<'_, String, Box<(dyn Any + Send)>>;
+            }
+        }
+    };
+}
+
+impl ProgressVars {
+    /// this returns the Box<dyn Any> that
+    /// is referenced by the key. if you want this
+    /// variable to be reused later, you must
+    /// reinsert it by calling insert_var
+    pub fn extract_var<S: AsRef<str>>(
+        &mut self,
+        key: S
+    ) -> Option<Box<dyn Any + Send>>{
+        self.vars.remove(key.as_ref())
+    }
+
+    /// creates a string from your key to be inserted
+    /// into the vars hashmap. no check is done to see
+    /// if the variable exists prior to inserting, so
+    /// that is up to you to do by checking var_exists if desired
+    pub fn insert_var<S: AsRef<str>>(&mut self, key: S, boxed: Box<dyn Any + Send>) {
+        self.vars.insert(key.as_ref().to_string(), boxed);
+    }
+
+    pub fn var_exists<S: AsRef<str>>(&self, key: S) -> bool {
+        self.vars.contains_key(key.as_ref())
+    }
+
+    pub fn drain_vars(&mut self) -> Drain<'_, String, Box<(dyn Any + Send)>> {
+        self.vars.drain()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_use_progress_vars() {
+        let mut progvars = ProgressVars::default();
+        let key = "key";
+        progvars.insert_var(
+            String::from(key),
+            Box::new(String::from("some value"))
+        );
+        let boxed = progvars.extract_var(key).unwrap();
+        if let Ok(x) = boxed.downcast::<String>() {
+            assert_eq!(x.as_str(), "some value");
+        } else {
+            assert!(false);
+        }
+    }
+}


### PR DESCRIPTION
biggest change in this PR is addition of progress vars. a progress stage returns an optional progress var hashmap. this hashmap is a Box<Any> so it can be downcast by the next stages to use variables that it might need from the previous stage.

Also some minor changes like refactoring, using seperate modules for some different logical pieces, etc.